### PR TITLE
Add JVM arg to enable Generational ZGC for Java 21 and add TransparentHugePages support

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -81,11 +81,11 @@ echo "  Bench: $BENCH"
 echo "  Memory: $MEMm"
 echo "  Queries/sec: $QPS"
 
-GCS=("G1" "Z" "Parallel" "Z")
-JAVA_VERSIONS=("24.0.2-open" "24.0.2-open" "24.0.2-open" "21-tem")
+#GCS=("G1" "Z" "Parallel" "Z")
+#JAVA_VERSIONS=("24.0.2-open" "24.0.2-open" "24.0.2-open" "21.0.8-tem")
 
 GCS=("G1" "Z")
-JAVA_VERSIONS=("25.ea.34-open" "25.ea.34-open")
+JAVA_VERSIONS=("25.ea.34-open" "21.0.8-tem")
 
 # GCS=("G1" "Z")
 # JAVA_VERSIONS=("24.0.2-open" "24.0.2-open")

--- a/bench.sh
+++ b/bench.sh
@@ -93,11 +93,53 @@ JAVA_VERSIONS=("25.ea.34-open" "25.ea.34-open")
 for i in "${!GCS[@]}"; do
     gc="${GCS[i]}"
     java_version="${JAVA_VERSIONS[i]}"
+
+    additional_opts=""
+    if [[ "$java_version" == "21"* && "$gc" == "Z" ]]; then
+        # Use Generational ZGC for Java 21+
+        additional_opts="-XX:+ZGenerational"
+    fi
+
+    if [[ "$gc" == "Z" && "$(uname)" == "Linux" ]]; then
+        # Ensure Transparent Huge Pages are set according to Netflix blog post recommendations
+        # https://netflixtechblog.com/bending-pause-times-to-your-will-with-generational-zgc-256629c9386b
+        # ZGC won't use THP and it will ignore -XX:+UseTransparentHugePages unless the correct settings are in place
+        thp_ok=1
+        if [[ "$(cat /sys/kernel/mm/transparent_hugepage/enabled)" != *"[madvise]"* ]]; then
+            echo "/sys/kernel/mm/transparent_hugepage/enabled isn't set to madvise."
+            thp_ok=0
+        fi
+        # this setting is especially needed for ZGC to make use of -XX:+UseTransparentHugePages
+        # with "cat /proc/meminfo | grep HugePages" you see how this will enable ZGC to use THP
+        # with ShmemHugePages
+        if [[ "$(cat /sys/kernel/mm/transparent_hugepage/shmem_enabled)" != *"[advise]"* ]]; then
+            echo "/sys/kernel/mm/transparent_hugepage/shmem_enabled isn't set to advise."
+            thp_ok=0
+        fi
+        if [[ "$(cat /sys/kernel/mm/transparent_hugepage/defrag)" != *"[defer]"* ]]; then
+            echo "/sys/kernel/mm/transparent_hugepage/defrag isn't set to defer."
+            thp_ok=0
+        fi
+        if [[ "$(cat /sys/kernel/mm/transparent_hugepage/khugepaged/defrag)" != "1" ]]; then
+            echo "/sys/kernel/mm/transparent_hugepage/khugepaged/defrag isn't set to 1."
+            thp_ok=0
+        fi
+        if [[ $thp_ok -eq 0 ]]; then
+            echo "Please set the Linux THP configuration recommended by https://netflixtechblog.com/bending-pause-times-to-your-will-with-generational-zgc-256629c9386b and re-run the benchmark."
+            echo "You can use the following commands:"
+            echo 'echo madvise | sudo tee /sys/kernel/mm/transparent_hugepage/enabled'
+            echo 'echo advise | sudo tee /sys/kernel/mm/transparent_hugepage/shmem_enabled'
+            echo 'echo defer | sudo tee /sys/kernel/mm/transparent_hugepage/defrag'
+            echo 'echo 1 | sudo tee /sys/kernel/mm/transparent_hugepage/khugepaged/defrag'
+            exit 1
+        fi
+    fi
+
     echo "Processing GC: $gc, Java Version: $java_version"
 
     sdk use java $java_version
     export RANDOM_COUNT=200
-    numactl --physcpubind=0-3 java -XX:+AlwaysPreTouch -XX:ActiveProcessorCount=4 -Xmx$(echo $MEM)m -Xms$(echo $MEM)m -XX:+Use$(echo $gc)GC -XX:StartFlightRecording:filename=$(echo $BENCH)_$(echo $gc)_$(echo $java_version)_$(echo $QPS).jfr,dumponexit=true,maxsize=500MB,settings=default.jfc -jar target/quarkus-app/quarkus-run.jar &
+    numactl --physcpubind=0-3 java -XX:+UseTransparentHugePages -XX:+AlwaysPreTouch -XX:ActiveProcessorCount=4 -Xmx$(echo $MEM)m -Xms$(echo $MEM)m -XX:+Use$(echo $gc)GC $additional_opts -XX:StartFlightRecording:filename=$(echo $BENCH)_$(echo $gc)_$(echo $java_version)_$(echo $QPS).jfr,dumponexit=true,maxsize=500MB,settings=default.jfc -jar target/quarkus-app/quarkus-run.jar &
     sleep 10
 
     # ../../oha -z $(echo $DURATION)s -c 200 --http2 -q $(echo $QPS) --latency-correction --output $(echo $BENCH)_$(echo $gc)_$(echo $java_version)_$(echo $QPS).csv --output-format csv http://localhost:8080/purchase_orders/$(echo $BENCH)


### PR DESCRIPTION
related to the [blog post comment](https://github.com/gunnarmorling/discussions.morling.dev/discussions/335#discussioncomment-14441044) I made:
- when testing Java 21, pass addition JVM arg `-XX:+ZGenerational`
- pass `-XX:+UseTransparentHugePages` to enable transparent huge pages
- add checks to ensure that Linux THP are such that ZGC can use transparent huge pages and follow [Netflix tech blog post recommendations for ZGC](https://netflixtechblog.com/bending-pause-times-to-your-will-with-generational-zgc-256629c9386b#:~:text=Our%20default%20configuration,following%20transparent_hugepage%20configuration%3A).
- replace `21-tem` with `21.0.8-tem` since `21-tem` points to a very old Java 21 version in SDKMAN

